### PR TITLE
Added dep.txt 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
 # auto-theme
 
 ### Dependencies:
--pywal  
--matplotlib  
--colorthief  
--Lybra-cursor  
+
+ * pywal  
+ * matplotlib  
+ * colorthief  
+ * Lybra-cursor  
+
+
+Install all dependencies with
+
+```sh
+pip3 install -r dep.txt
+```

--- a/dep.txt
+++ b/dep.txt
@@ -1,0 +1,4 @@
+pywal  
+matplotlib  
+colorthief  
+Lybra-cursor  


### PR DESCRIPTION
dep.txt lists all dependencies which allows you to install them this way:

```
pip3 install -r dep.txt
```

I added all the dependencies listed, but I think only `colorThief` and `matplotlib` are required. Im not sure if `Lybra-cursor` exists